### PR TITLE
Add model selection and style support with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ This is a minimal chat application using FastAPI.
 ## Tests
 
 Run `pytest`.
+
+## Features
+
+- Auswahl zwischen verschiedenen KI-Modellen und Stilen.
+- Automatisches Fallback auf kleinere Modelle bei Fehlern.

--- a/app/config.py
+++ b/app/config.py
@@ -25,7 +25,10 @@ _cached_config: Optional[Config] = None
 def load_config(path: str = "config.yaml") -> Config:
     global _cached_config
     if _cached_config is None:
-        with open(path, 'r', encoding='utf-8') as f:
-            data = yaml.safe_load(f) or {}
+        cfg_path = Path(path)
+        data = {}
+        if cfg_path.exists():
+            with cfg_path.open('r', encoding='utf-8') as f:
+                data = yaml.safe_load(f) or {}
         _cached_config = Config(**data)
     return _cached_config

--- a/app/main.py
+++ b/app/main.py
@@ -18,5 +18,7 @@ async def index(request: Request):
 async def chat(request: Request):
     data = await request.json()
     prompt = data.get("prompt", "")
-    result = await model_service.generate(prompt)
+    model = data.get("model")
+    style = data.get("style")
+    result = await model_service.generate(prompt, model=model, style=style)
     return result

--- a/app/services/model_service.py
+++ b/app/services/model_service.py
@@ -1,29 +1,45 @@
-from typing import List, Dict, Optional
-import httpx
+from typing import Dict, List, Optional
 from .logger import get_logger
 from app.config import load_config
 
 logger = get_logger(__name__)
 
+SYSTEM_PROMPTS = {
+    "nett": "Du bist eine höfliche und hilfsbereite Assistenz.",
+    "unhöflich": "Du antwortest absichtlich unhöflich und respektlos.",
+    "optimierer": "Du optimierst die Prompts der Nutzenden bevor sie an das Modell gesendet werden."
+}
+
 class ModelService:
-    def __init__(self):
+    """Service der mehrere Modelle mit Fallback ansteuert."""
+
+    def __init__(self) -> None:
         cfg = load_config()
-        self.models = [
-            cfg.default_model,
-            "gpt-4.1-mini",
-            "gpt-4.1-nano",
-        ]
+        # Modellreihenfolge: default_model zuerst, danach weitere konfigurierte
+        if cfg.models:
+            self.models: List[str] = [cfg.default_model] + [m for m in cfg.models.keys() if m != cfg.default_model]
+        else:
+            # Fallback auf einige Standardmodelle, wenn keine Konfiguration vorhanden
+            self.models = [cfg.default_model, "gpt-4.1-mini", "gpt-4.1-nano"]
         self.api_keys = cfg.api_keys
 
-    async def generate(self, prompt: str) -> Dict[str, str]:
-        for model in self.models:
+    async def call_model(self, model: str, prompt: str, system_prompt: Optional[str] = None, image: Optional[str] = None) -> Dict[str, str]:
+        """Stub für den eigentlichen API Aufruf."""
+        logger.info("model %s called", model)
+        # hier würde der echte API Call erfolgen (httpx etc.)
+        # Für Demozwecke geben wir einfach eine Echo Antwort zurück
+        sp = f" [{system_prompt}]" if system_prompt else ""
+        return {"model": model, "response": f"Echo{sp} {prompt}"}
+
+    async def generate(self, prompt: str, model: Optional[str] = None, style: Optional[str] = None, image: Optional[str] = None) -> Dict[str, str]:
+        """Erzeuge eine Antwort mit optionaler Modellwahl und Stil."""
+        system_prompt = SYSTEM_PROMPTS.get(style or "", None)
+        order = [model] if model else []
+        order += [m for m in self.models if m not in order]
+        for m in order:
             try:
-                logger.info(f"Trying model {model}")
-                # Placeholder for actual API call
-                # response = await httpx.post(...)
-                # Return mock response
-                return {"model": model, "response": f"Echo from {model}: {prompt}"}
-            except Exception as e:
-                logger.error(f"Model {model} failed: {e}")
+                return await self.call_model(m, prompt, system_prompt, image)
+            except Exception as exc:  # pragma: no cover - Fehlerpfad
+                logger.error("model %s failed: %s", m, exc)
                 continue
         raise RuntimeError("All models failed")

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -3,12 +3,14 @@ document.getElementById('chat-form').addEventListener('submit', async (e) => {
     const input = document.getElementById('prompt');
     const prompt = input.value;
     if(!prompt) return;
+    const model = document.getElementById('model').value;
+    const style = document.getElementById('style').value;
     addMessage('user', prompt);
     input.value='';
     const res = await fetch('/api/chat', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({prompt})
+        body: JSON.stringify({prompt, model, style})
     });
     const data = await res.json();
     addMessage('assistant', data.response);

--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -10,6 +10,23 @@
     <div id="messages"></div>
     <form id="chat-form">
         <input type="text" id="prompt" placeholder="Nachricht" required>
+        <select id="model">
+            <option value="">Standard</option>
+            <option value="gpt-4.1">gpt-4.1</option>
+            <option value="gpt-4.1-mini">gpt-4.1-mini</option>
+            <option value="gpt-4.1-nano">gpt-4.1-nano</option>
+            <option value="codestral-25.01">Codestral 25.01</option>
+            <option value="grok-3">Grok 3</option>
+            <option value="phi-4-reasoning">Phi-4-Reasoning</option>
+            <option value="deepseek-r1">DeepSeek-R1</option>
+            <option value="llama-3.2-11b-vision-instruct">Llama-3.2-11B-Vision-Instruct</option>
+        </select>
+        <select id="style">
+            <option value="">Neutral</option>
+            <option value="nett">Nett</option>
+            <option value="unhöflich">Unhöflich</option>
+            <option value="optimierer">Prompt-Optimierer</option>
+        </select>
         <button type="submit">Senden</button>
     </form>
 </div>

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,3 +15,8 @@ models:
   gpt-4.1: {}
   gpt-4.1-mini: {}
   gpt-4.1-nano: {}
+  codestral-25.01: {}
+  grok-3: {}
+  phi-4-reasoning: {}
+  deepseek-r1: {}
+  llama-3.2-11b-vision-instruct: {}


### PR DESCRIPTION
## Summary
- support choosing different AI models and system prompt styles
- include dynamic fallback across configured models
- expose model/style options in chat UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa7155a0c8331bf25a95bae4adc53